### PR TITLE
Performance Improvements

### DIFF
--- a/src/Invio.QueryProvider.MySql/DataReader.fs
+++ b/src/Invio.QueryProvider.MySql/DataReader.fs
@@ -1,7 +1,6 @@
 ﻿module Invio.QueryProvider.MySql.DataReader
 
 open System
-open System.Collections
 open System.Linq
 open System.Reflection
 open Microsoft.FSharp.Reflection
@@ -28,12 +27,13 @@ and TypeOrValueOrLambdaConstructionInfo =
 
 and TypeConstructionInfo = {
     Type : System.Type
-    ConstructorArgs : TypeOrValueOrLambdaConstructionInfo seq
+    ConstructorArgs : TypeOrValueOrLambdaConstructionInfo list
     PropertySets : (TypeOrValueOrLambdaConstructionInfo * System.Reflection.PropertyInfo) seq
 }
 
 and LambdaConstructionInfo = {
     Lambda : System.Linq.Expressions.LambdaExpression
+    Delegate : Delegate
     Parameters : TypeOrValueOrLambdaConstructionInfo seq
 }
 
@@ -103,7 +103,7 @@ and invokeLambda reader lambdaCtor =
             | TypeOrValueOrLambdaConstructionInfo.DateTime i -> readDateTime ((reader.GetValue i))
             | TypeOrValueOrLambdaConstructionInfo.Bool i -> readBool ((reader.GetValue i))
             | TypeOrValueOrLambdaConstructionInfo.Enum enumCtor -> constructEnum reader enumCtor)
-    lambdaCtor.Lambda.Compile().DynamicInvoke(paramValues |> Seq.toArray)
+    lambdaCtor.Delegate.DynamicInvoke(paramValues |> Seq.toArray)
 
 and constructEnum reader enumCtor =
     Enum.ToObject(enumCtor.Type, (reader.GetValue enumCtor.Index))

--- a/src/Invio.QueryProvider.MySql/QueryProvider.fs
+++ b/src/Invio.QueryProvider.MySql/QueryProvider.fs
@@ -5,16 +5,15 @@ open System.Collections
 open System.Collections.Generic
 open System.Collections.Immutable
 open System.Linq.Expressions
+open System.Reflection
 
 open MySql.Data.MySqlClient
 
-open System.Reflection
 open Invio.Extensions.Reflection
 open Invio.QueryProvider
 open Invio.QueryProvider.MySql.QueryTranslator
 open Invio.QueryProvider.MySql.QueryTranslatorUtilities
 
-type gfdi = delegate of Expression -> IEnumerable<obj>
 /// <summary>
 ///   An <see creft="System.Linq.IQueryProvider" /> implementation for
 ///   <see cref="MySqlConnection" />.


### PR DESCRIPTION
Eliminated unnecessary TypeConverter handling for well known types.
Added caching of compiled lambdas for the life of each query.

Before TypeConverter support was introduced:
```
Retrieved 700 entities via linq in 1599 ms.
Fetch Entities [1,601 ms]
└─ Get Entity List x100 [1,592 ms] (99.388%)
  ├─ Open Transaction x100 [543 ms] (34.100%)
  ├─ Create Repository x100 [83 ms] (5.240%)
  └─ Where & To List x100 [892 ms] (56.041%)
```

After TypeConverter support:
```
Retrieved 700 entities via linq in 12498 ms.
Fetch Entities [12,500 ms]
└─ Get Entity List x100 [12,490 ms] (99.919%)
  ├─ Open Transaction x100 [688 ms] (5.509%)
  ├─ Create Repository x100 [100 ms] (0.804%)
  └─ Where & To List x100 [11,559 ms] (92.547%)
```

After these performance improvements:
```
Retrieved 700 entities via linq in 1879 ms.
Fetch Entities [1,881 ms]
└─ Get Entity List x100 [1,872 ms] (99.495%)
  ├─ Open Transaction x100 [597 ms] (31.907%)
  ├─ Create Repository x100 [87 ms] (4.654%)
  └─ Where & To List x100 [1,096 ms] (58.546%)
```
